### PR TITLE
Add Spring Boot + Micrometer's default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Chrome Extension which makes plain Prometheus metrics easier to read.
 
-This extension is a simple syntax highlighter for plain text Prometheus metrics. As it is hard to detect whether a plain text response is coming from Prometheus, it is currently limited to '/metrics', '/federate' and '/probe' paths.
+This extension is a simple syntax highlighter for plain text Prometheus metrics. As it is hard to detect whether a plain text response is coming from Prometheus, it is currently limited to '/metrics', '/federate', '/probe', '/prometheus' and '/actuator/prometheus' paths.
 
 ###### before:
 ![](_images/before.png)

--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -63,7 +63,7 @@
     // 'version' part of the content type to verify.
     if (
       document.contentType !== 'text/plain' ||
-      !['/metrics', '/federate', '/probe'].includes(document.location.pathname)
+      !['/metrics', '/federate', '/probe', '/prometheus', '/actuator/prometheus'].includes(document.location.pathname)
     ) {
       return
     }


### PR DESCRIPTION
Hello.

I'd like to add [Spring Boot](https://spring.io/projects/spring-boot) + [Micrometer](https://micrometer.io/)'s default path.

Actually, the path is different between Spring Boot 1.5 and 2.0.

# Spring Boot 1.5

The default path is `/prometheus`

ref:
https://micrometer.io/docs/ref/spring/1.5#_prometheus

# Spring Boot 2.0

The default path is `/actuator/prometheus`

ref:
https://docs.spring.io/spring-boot/docs/2.0.2.RELEASE/reference/htmlsingle/#production-ready-metrics-export-prometheus
