### PR TITLE
Add ability to provide custom paths RegExps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Chrome Extension which makes plain Prometheus metrics easier to read.
 
-This extension is a simple syntax highlighter for plain text Prometheus metrics. As it is hard to detect whether a plain text response is coming from Prometheus, it is currently limited to '/metrics', '/federate', '/probe', '/prometheus' and '/actuator/prometheus' paths.
+This extension is a simple syntax highlighter for plain text Prometheus metrics. 
+By default it works on URL paths matching '/metrics', '/federate', '/probe', '/prometheus' and '/actuator/prometheus'.
+
+By clicking on a plugin icon you can set your own path's RegExps separated by new line, this will overwrite default list.
 
 ###### before:
 ![](_images/before.png)

--- a/extension/html/popup.html
+++ b/extension/html/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+	<style>
+	  body {
+		height: 300px;
+		width: 300px;
+		outline: none;
+	  }
+	</style>
+  </head>
+  <body>
+	<label>Path RegEx to handle separated by new line (example: ^/prometheus)
+		<textarea id="paths-to-handle" style="width:100%;height:100%;"></textarea></label>
+  </body>
+  <script src="../js/popup.js"></script>
+</html>

--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -57,17 +57,25 @@
     }
   })
 
-  function ready () {
+  function ready (data) {
     // Check if it is a Prometheus plain text response
     // This is quite a basic assumption, as the browser cannot access the
     // 'version' part of the content type to verify.
-    if (
-      document.contentType !== 'text/plain' ||
-      !['/metrics', '/federate', '/probe', '/prometheus', '/actuator/prometheus'].includes(document.location.pathname)
-    ) {
+    let paths = data.paths.length ? data.paths : []
+    
+    if (document.contentType !== 'text/plain') {
       return
     }
+    
+    for (var i = 0; i < paths.length; ++i) {
+      if (document.location.pathname.match(paths[i])) {
+        format()
+        break
+      }
+    }
+  }
 
+  function format() {
     // Check if plain text wrapped in <pre> element exists and doesn't exceed maxBodyLength
     const pre = document.body.querySelector('pre')
     const rawBody = pre && pre.innerText
@@ -84,5 +92,7 @@
     })
   }
 
-  document.addEventListener('DOMContentLoaded', ready, false)
+  document.addEventListener('DOMContentLoaded', function() {
+    chrome.storage.sync.get({paths: []}, ready);
+  });
 })()

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -1,0 +1,16 @@
+let pathsElement = document.getElementById('paths-to-handle');
+
+pathsElement.addEventListener('keyup', function(element) {
+	let paths = element.target.value;
+	let sliced = []
+	if (paths != "") {
+		sliced = paths.split("\n")
+	}
+	chrome.storage.sync.set({paths: sliced}) 
+});
+
+document.addEventListener('DOMContentLoaded', function() {
+	chrome.storage.sync.get({paths: []}, function(data) {
+		pathsElement.value = data.paths.join("\n")
+	})
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -16,5 +16,13 @@
   "content_scripts": [
     { "matches": ["<all_urls>"], "js": ["js/content.js"], "run_at": "document_start" }
   ],
-  "permissions":["*://*/*", "<all_urls>"]
+  "browser_action": {
+    "default_popup": "html/popup.html",
+    "default_icon": {
+      "128": "icons/128.png",
+      "48": "icons/48.png",
+      "32": "icons/32.png"
+    }
+  },
+  "permissions":["*://*/*", "<all_urls>", "storage", "declarativeContent"]
 }


### PR DESCRIPTION
This fixes #3 

Added little textarea popup to fill with user specific metric RegEx paths separated by newline.
Data is persisted in plugin storage.
Empty list defaults to current list 

I have also looked into #1 and there is a way to access response headers https://developer.chrome.com/extensions/webRequest#event-onHeadersReceived but when I almost made it work I came to to few conclusions why maybe it's not best idea:

- plugin gets more complicated,
- any other app which uses `version` in Content-Type will be affected,
- we require permission to view user's traffic and I think it's too much for such little plugin,
- proposed solution covers 99% cases.

@fhemberger It would be great if you could look at this 👍 