### PR TITLE
Fix highlighting for empty label values

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -36,7 +36,7 @@
           if (tmp && tmp.length > 1) {
             let { metric, tags, value } = tmp.groups
             if (tags) {
-              tags = tags.replace(/([^,]+?)="(.+?)"/g, '<span class="label-key">$1</span>="<span class="label-value">$2</span>"')
+              tags = tags.replace(/([^,]+?)="(.*?)"/g, '<span class="label-key">$1</span>="<span class="label-value">$2</span>"')
               tags = `{${tags}}`
             }
 


### PR DESCRIPTION
Currently when tag label is empty, the next label is colored in `value` color. Example:
 ```
node_network_info{device="lo",duplex="",ifalias="",operstate="unknown"} 1
                                       ^^^^^^^^^^^^
                                      This is all green
```
