### PR TITLE
Use Atom One dark/light theme depending on color scheme

### DIFF
--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -36,22 +36,16 @@ const sendBodyToFormatter = (storedData) => {
 }
 
 const renderFormattedHTML = (html) => {
-  const link = document.createElement('link');
-  link.href='https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap';
-  link.rel='stylesheet';
-  document.getElementsByTagName('head')[0].appendChild(link)
-
   const style = `
     pre {
-      display:none
+      display: none;
     }
     #promformat {
-      font-family: 'Source Code Pro', monospace;
+      font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
       word-wrap: break-word;
       white-space: pre-wrap;
     }
     .comment {
-      color: #6a737d;
       display: inline-block;
     }
     br + .comment {
@@ -61,20 +55,20 @@ const renderFormattedHTML = (html) => {
       padding-top: 0;
     }
 
-    body         { background-color: #FAFAFA; color: #383A42 }
-    .metric      { color: #E45649 }
-    .value       { color: #A625A4 }
-    .label-key   { color: #4078F2 }
-    .label-value { color: #50A14F }
-    .comment     { color: #A0A1A7 }
+    body         { background-color: #fff; color: #000 }
+    .metric      { color: #de3121 }
+    .value       { color: #a625a4 }
+    .label-key   { color: #2d6bf0 }
+    .label-value { color: #418240 }
+    .comment     { color: #73747d }
 
     @media (prefers-color-scheme:dark) {
-      body         { background-color: #282C34; color: #ABB2BF }
-      .metric      { color: #DE6A73 }
-      .value       { color: #C678DD }
-      .label-key   { color: #60AFEF }
-      .label-value { color: #98C379 }
-      .comment     { color: #5A616E }
+      body         { background-color: #1d2025; color: #fff }
+      .metric      { color: #de6a73 }
+      .value       { color: #98c379 }
+      .label-key   { color: #60afef }
+      .label-value { color: #98c379 }
+      .comment     { color: #9297a0 }
     }
     `
 

--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -36,12 +36,17 @@ const sendBodyToFormatter = (storedData) => {
 }
 
 const renderFormattedHTML = (html) => {
+  const link = document.createElement('link');
+  link.href='https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap';
+  link.rel='stylesheet';
+  document.getElementsByTagName('head')[0].appendChild(link)
+
   const style = `
     pre {
       display:none
     }
     #promformat {
-      font-family: monospace;
+      font-family: 'Source Code Pro', monospace;
       word-wrap: break-word;
       white-space: pre-wrap;
     }
@@ -53,13 +58,15 @@ const renderFormattedHTML = (html) => {
       padding-top: 1em;
     }
     .comment + br + .comment {
-        padding-top: 0;
+      padding-top: 0;
     }
 
-    .metric      { color: #000 }
-    .value       { color: #ff20ed }
-    .label-key   { color: blue }
-    .label-value { color: green }
+    body         { background-color: #FAFAFA; color: #383A42 }
+    .metric      { color: #E45649 }
+    .value       { color: #A625A4 }
+    .label-key   { color: #4078F2 }
+    .label-value { color: #50A14F }
+    .comment     { color: #A0A1A7 }
     `
 
   // Insert CSS

--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -67,6 +67,15 @@ const renderFormattedHTML = (html) => {
     .label-key   { color: #4078F2 }
     .label-value { color: #50A14F }
     .comment     { color: #A0A1A7 }
+
+    @media (prefers-color-scheme:dark) {
+      body         { background-color: #282C34; color: #ABB2BF }
+      .metric      { color: #DE6A73 }
+      .value       { color: #C678DD }
+      .label-key   { color: #60AFEF }
+      .label-value { color: #98C379 }
+      .comment     { color: #5A616E }
+    }
     `
 
   // Insert CSS


### PR DESCRIPTION
Closes #10 

This PR sets the default theme to Atom One Light:

![image](https://user-images.githubusercontent.com/5648814/85061261-8726a180-b174-11ea-8d73-c3c1460fce13.png)

Or Atom One Dark if the user's color-scheme is set to dark:

![image](https://user-images.githubusercontent.com/5648814/85061307-9ad20800-b174-11ea-8775-cbe775b39183.png)

The default for this theme is Mozilla Fira. However, I am using Source Code Pro from Google fonts because I thought it looked better here.

Any edits / suggestions are welcome.